### PR TITLE
Withdraw custom amount from the fund

### DIFF
--- a/contracts/Fund.sol
+++ b/contracts/Fund.sol
@@ -21,12 +21,13 @@ contract Fund {
 
     /**
      * @notice Withdraw money from the fund.
-     * It will withdraw all the money the user sent to the fund to its wallet.
-     * TODO: Enable the user to withdraw only a fraction of its funding.
+     * @param _amount the amount to withdraw from the fund.
      */
-    function withdraw() public payable {
-        totalFunds -= addressToAmountFunded[msg.sender];
-        payable(msg.sender).transfer(addressToAmountFunded[msg.sender]);
+    function withdraw(uint256 _amount) public payable {
+        require(_amount <= addressToAmountFunded[msg.sender], "You can't withdraw more than what you deposited");
+        addressToAmountFunded[msg.sender] -= _amount;
+        totalFunds -= _amount;
+        payable(msg.sender).transfer(_amount);
     }
 
     /**

--- a/test/fund.js
+++ b/test/fund.js
@@ -65,8 +65,8 @@ describe("Fund smart contract tests", () => {
             funds = await contract.getTotalFunds();
             expect(funds).to.equal(amountDeposited);
 
-            // Withdraw money from the fund.
-            const txn2 = await contract.withdraw();
+            // Withdraw all the money from the fund.
+            const txn2 = await contract.withdraw(amountDeposited);
             await txn2.wait();
 
             // Check that the fund is now empty.

--- a/test/fund.js
+++ b/test/fund.js
@@ -65,13 +65,13 @@ describe("Fund smart contract tests", () => {
             funds = await contract.getTotalFunds();
             expect(funds).to.equal(amountDeposited);
 
-            // Withdraw all the money from the fund.
-            const txn2 = await contract.withdraw(amountDeposited);
+            // Withdraw only one ether from the fund.
+            const txn2 = await contract.withdraw(utils.parseEther("1"));
             await txn2.wait();
 
             // Check that the fund is now empty.
             funds = await contract.getTotalFunds();
-            expect(funds).to.equal(0);
+            expect(funds).to.equal(utils.parseEther(".5"));
         });
     })
 


### PR DESCRIPTION
## Description
Enable the user to withdraw any custom amout from the fund (of course, it checks that the user has deposited these funds previously). Tests have been updated and new tests have been written to test this new feature.

## Related issue
Closes #9.
#2 (this PR has been stale for more than a week...).