### PR TITLE
Fix gas estimation

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -39,7 +39,7 @@ module.exports = {
   },
   gasReporter: {
     currency: "EUR",
-    token: "MATIC",
+    token: "AVAX",
     coinmarketcap: COINMARKETCAP_API_KEY,
   }
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -5,7 +5,15 @@ require("dotenv").config();
 const { COINMARKETCAP_API_KEY } = process.env;
 
 module.exports = {
-  solidity: "0.8.4",
+  solidity: {
+    version: "0.8.4",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
   networks: {
     local: {
       url: "http://localhost:9650/ext/bc/C/rpc",


### PR DESCRIPTION
## Description
- Gas reporter used `MATIC` token price instead of `AVAX` token price to estimate the cost of our smart contract functions.
- Enable optimiser to reduce even more the costs (divide deployment cost by more than two and reduce functions cost).

Before enabling optimiser:
![before](https://user-images.githubusercontent.com/28714795/164029831-d497aaae-b3c7-4b23-88d6-9fcc55f7909f.png)

After enabling optimiser:
![after](https://user-images.githubusercontent.com/28714795/164029818-1883bbf3-f4ff-4cb7-a2c0-6de07be36c51.png)

